### PR TITLE
Don't unshift data if the record is already in there.

### DIFF
--- a/src/base/index.js
+++ b/src/base/index.js
@@ -115,6 +115,7 @@ class FeathersReact extends Component {
   handleCreate = created => {
     const { query } = this.props;
     const { data, pagination } = this.state;
+    const shouldUpdate = this.isRecordInData(created);
     const keys = Object.keys(query)
       .filter(key => (
         key.includes('$') && !allowedOperators.includes(key)
@@ -122,7 +123,7 @@ class FeathersReact extends Component {
     const filter = sift(omit(query, ...keys));
     let p = null;
 
-    if (filter(created)) {
+    if (filter(created) && !shouldUpdate.isInData) {
       data.unshift(created);
 
       if (data.length > pagination.pageSize) {


### PR DESCRIPTION
This happens when you implement a hook to prevent duplication. The `created` event will still be emited, but no new records will be created.

The duplication is prevented by setting `context.result` in a before hook.